### PR TITLE
entgql: allow extra fields on generated mutation inputs via helper templates

### DIFF
--- a/entgql/template/mutation_input.tmpl
+++ b/entgql/template/mutation_input.tmpl
@@ -54,6 +54,12 @@ import (
                 {{- end }}
             {{- end }}
         {{- end }}
+
+        {{- with $tmpls := matchTemplate "helper/gql_mutation_input/fields/*"  }}
+            {{- range $tmpl := $tmpls }}
+                {{- xtemplate $tmpl $n }}
+            {{- end }}
+        {{- end }}
     }
 
     // Mutate applies the {{ $input }} on the {{ $n.MutationName }} builder.
@@ -107,6 +113,12 @@ import (
                         m.{{ $e.MutationRemove }}(v...)
                     }
                 {{- end }}
+            {{- end }}
+        {{- end }}
+
+        {{- with $tmpls := matchTemplate "helper/gql_mutation_input/mutate/*"  }}
+            {{- range $tmpl := $tmpls }}
+                {{- xtemplate $tmpl $n }}
             {{- end }}
         {{- end }}
     }


### PR DESCRIPTION
## Summary
Port of upstream [ent/contrib#608](https://github.com/ent/contrib/pull/608) onto our fork: `mutation_input.tmpl` gains two `matchTemplate` hook points so a consuming service can inject extra fields into the generated `Create<T>Input`/`Update<T>Input` structs (and extra statements into `Mutate`) via its own `ent-templates/helper/gql_mutation_input/{fields,mutate}/*` templates — no further fork changes needed per use case.

First consumer: cad-domain, which extends `Create/UpdateCadModelInput` with sharing fields (owner/viewer user+group IDs) for the CAD-model mutation surface.

## Test plan
- `go build ./entgql/...` clean.
- Fork's `go test ./entgql` fails identically on clean `master` (ancient `x/tools v0.7.0` package-loader crash on current Go/macOS) — pre-existing, unrelated.
- Consumer verification: cad-domain `go generate .` against this branch produces **byte-identical** `ent/gql_mutation_input.go` when no helper templates are present (hooks are a strict no-op), and `go build ./... && go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136CtS4Jsox8dS9GMNmHGk4