### PR TITLE
entgql: correct FederationEntityTemplate usage guidance

### DIFF
--- a/entgql/template.go
+++ b/entgql/template.go
@@ -71,10 +71,16 @@ var (
 	WherePTemplate = parseT("template/where_p.tmpl")
 
 	// FederationEntityTemplate emits an IsEntity() method (fedruntime.Entity) on
-	// every generated model. Opt-in for federated subgraphs:
+	// every generated model. Opt-in for federated subgraphs — inject it through
+	// the entc template pool:
 	//
-	//	entgql.WithTemplates(append(entgql.AllTemplates, entgql.FederationEntityTemplate)...)
+	//	entc.Generate("./ent/schema", &gen.Config{
+	//		Templates: []*gen.Template{entgql.FederationEntityTemplate},
+	//	}, entc.Extensions(ex))
 	//
+	// Do NOT pass it via entgql.WithTemplates: that replaces the extension's
+	// template set wholesale and silently drops the where-input template that
+	// WithWhereInputs appends (where-filter arguments vanish from edges).
 	// (Absorbed from the spread-ai/ent-templates repo.)
 	FederationEntityTemplate = parseT("template/gql_federation.tmpl")
 


### PR DESCRIPTION
Doc-only. The usage example on `FederationEntityTemplate` recommended `entgql.WithTemplates(append(entgql.AllTemplates, ...)...)` — that pattern replaces the extension's template set wholesale and silently drops the where-input template `WithWhereInputs(true)` appends, so where-filter arguments vanish from generated edges. Caught during cad-domain's v0.2.0 adoption; the safe pattern is injection via `gen.Config.Templates`, now documented (with a warning) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136CtS4Jsox8dS9GMNmHGk4